### PR TITLE
Change the behavior of createS3PutObjectParam

### DIFF
--- a/lib/upload-param.js
+++ b/lib/upload-param.js
@@ -7,19 +7,23 @@ const filesAsync = require("files-async");
 const UploadParam = {};
 
 UploadParam.createS3PutObjectParam = async (bucket, key, pathname) => {
-    try {
-        const body = await fs.readFile(pathname);
-        const contentType = mime.lookup(pathname);
+    const body = await fs.readFile(pathname);
+    const contentType = mime.lookup(pathname);
+    if(contentType === false) {
         return {
-            Body: contentType.match(/^text\//) ? body.toString() : body,
+            Body: body,
             Bucket: bucket,
             Key: key,
             CacheControl: "no-cache",
-            ContentType: contentType,
         };
-    } catch(err) {
-        console.warn(err.message);
     }
+    return {
+        Body: contentType.match(/^text\//) ? body.toString() : body,
+        Bucket: bucket,
+        Key: key,
+        CacheControl: "no-cache",
+        ContentType: contentType,
+    };
 };
 
 UploadParam.createS3BucketKey = async (dstRoot, srcPath) => {

--- a/test/upload-param.test.js
+++ b/test/upload-param.test.js
@@ -72,6 +72,30 @@ describe("lib/upload-param.js", ()=>{
         it("should be exported", () => {
             assert.instanceOf(createS3PutObjectParam, Function);
         });
+        it("should throw if the input file does not exist", async () => {
+            await createTestDir();
+            try {
+                await createS3PutObjectParam(
+                    "BucketName", "test/data", "there-is-no-file");
+                assert(false);
+            } catch( err ) {
+                assert(true);
+            } finally {
+                await removeTestDir();
+            }
+        });
+        it("should not yield a ContentType property when the MIME-type is not be determined", async () => {
+            await createTestDir();
+            try {
+                const param = await createS3PutObjectParam(
+                    "BucketName",
+                    "test/data/",
+                    "test/data/dA0/fB1.no-mime-type");
+                assert.notProperty(param, "ContentType");
+            } finally {
+                await removeTestDir();
+            }
+        });
     });
     describe(".createS3BucketKey", ()=>{
         it("should be exported", () => {


### PR DESCRIPTION
* Not to yield a property ContentType if it could not be determined.
* Throw an error if the input file does not exist.

This commit is relating with the issue #11.